### PR TITLE
This commit adds a checklist to the README.md file to indicate the co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@
 
 [AUTOMATIC1111's Stable Diffusion WebUI](https://github.com/AUTOMATIC1111/stable-diffusion-webui) is one of the most powerful tools in the generative AI space. Stable Boy puts that power into GIMP 2.10 by calling into A1111 WebUI's API.
 
+## Compatibility
+
+- [X] GIMP 2.10
+- [ ] GIMP 3.0.4 (Not compatible, requires porting to the new GIMP 3 API)
+
 Here's a short demo video (of v0.1 ... haven't found time to make a new one):
 
 [![A short demo](./public/images/demo-video-screenshot.png)](https://youtu.be/YMVog30OcTI)


### PR DESCRIPTION
…mpatibility of the plugin with different GIMP versions.

Based on the GIMP 3.0 release notes and API changes, it is assumed that this plugin, written for GIMP 2.10, is not compatible with GIMP 3.0.4 without porting.